### PR TITLE
Fix tsconfig reference

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
-  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.


### PR DESCRIPTION
## Summary
- remove reference to `@tsconfig/svelte`
- specify `moduleResolution` so TypeScript works without extra config

## Testing
- `tsc -p tsconfig.app.json` *(fails: Cannot find module 'svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68405ce00afc8329b82b6cae688c8a10